### PR TITLE
Fix/0514 qa

### DIFF
--- a/src/constants/optionList.ts
+++ b/src/constants/optionList.ts
@@ -21,7 +21,7 @@ export const positionOptionList = [
   { label: 'iOS', value: 'IOS' },
   { label: 'Flutter', value: 'FLUTTER' },
   { label: 'Server', value: 'SERVER' },
-  { label: '운영진', value: 'STAFF' },
+  { label: '운영진', value: '운영진' },
 ];
 
 export const rejectOptionList = [{ label: '직접입력', value: '직접입력' }];

--- a/src/constants/tableHeader.ts
+++ b/src/constants/tableHeader.ts
@@ -17,8 +17,8 @@ export const applicationHeader = [
 ];
 
 export const memberListHeader = [
-  '번호',
   '이름',
+  '이메일',
   '최근활동기수',
   '직군',
   '권한',

--- a/src/constants/tableHeader.ts
+++ b/src/constants/tableHeader.ts
@@ -1,4 +1,4 @@
-export const noticeHeader = ['번호', '제목', '타입', '이름', '작성일'];
+export const noticeHeader = ['제목', '타입', '이름', '작성일'];
 
 export const linkHeader = ['링크 이름', 'URL', '수정'];
 

--- a/src/constants/tableHeader.ts
+++ b/src/constants/tableHeader.ts
@@ -5,7 +5,6 @@ export const linkHeader = ['링크 이름', 'URL', '수정'];
 export const generationHeader = ['기수', '활동기간', '상태'];
 
 export const applicationHeader = [
-  '번호',
   '이름',
   '이메일',
   '상태',

--- a/src/features/attendance/BundleEditPopup.tsx
+++ b/src/features/attendance/BundleEditPopup.tsx
@@ -2,24 +2,23 @@ import OutlinedButton from '@compnents/Button/OutlinedButton';
 import SolidButton from '@compnents/Button/SolidButton';
 import FlexBox from '@compnents/commons/FlexBox';
 import Select from '@compnents/commons/Select';
+import Typography from '@compnents/commons/Typography';
 import PopupContainer from '@compnents/popup/PopupContainer';
 import { attendanceOptions } from '@constants/optionList';
 import { useEditAttendanceBundleMutation } from '@queries/attendance/useEditAttendanceBundleMutation';
 import { useAttendanceStore } from '@stores/attendanceStore';
 import { useQueryClient } from '@tanstack/react-query';
-import { ErrorResponse } from 'apis/common/types';
-import { isAxiosError } from 'axios';
-import { FC, useState } from 'react';
-import styled from 'styled-components';
-import { showErrorToast } from 'types/showErrorToast';
-
-import Typography from '@compnents/commons/Typography';
 import {
   AttendanceGroup,
   AttendanceSession,
   AttendanceStatusValueType,
   EditAttendanceReq,
 } from 'apis/attendance/types';
+import { ErrorResponse } from 'apis/common/types';
+import { isAxiosError } from 'axios';
+import { FC, useState } from 'react';
+import styled from 'styled-components';
+import { showErrorToast } from 'types/showErrorToast';
 
 interface Props {
   onClose: VoidFunction;

--- a/src/features/member/code/CodeEditPopup.tsx
+++ b/src/features/member/code/CodeEditPopup.tsx
@@ -4,8 +4,11 @@ import { FC, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import styled from 'styled-components';
 
+import Close from '@assets/Close';
+import IconButton from '@compnents/Button/IconButton';
 import SolidButton from '@compnents/Button/SolidButton';
 import Chip from '@compnents/commons/Chip';
+import FlexBox from '@compnents/commons/FlexBox';
 import TextInput from '@compnents/commons/TextInput';
 import Typography from '@compnents/commons/Typography';
 import { useDeleteMemberCodeMutation } from '@queries/auth/useDeleteMemberCodeMutation';
@@ -18,6 +21,7 @@ import {
 } from 'apis/auth/types';
 import { ErrorResponse } from 'apis/common/types';
 import { RoleName } from 'apis/user/types';
+import theme from 'styles/theme';
 import { UserRoleType } from 'types/formTypes';
 import { showErrorToast } from 'types/showErrorToast';
 
@@ -95,9 +99,14 @@ const CodeEditPopup: FC<Props> = (props) => {
           onClick={(e) => e.stopPropagation()}
           onSubmit={handleSubmit(onSubmit)}
         >
-          <Typography color="label-normal" variant="headline1Bold">
-            코드값 수정
-          </Typography>
+          <FlexBox justify="space-between">
+            <Typography color="label-normal" variant="headline1Bold">
+              코드값 수정
+            </Typography>
+            <IconButton onClick={() => handleEditPopup(false)}>
+              <Close color={theme.colors.label.alternative} />
+            </IconButton>
+          </FlexBox>
           <Chip
             role={selectedCode?.role?.name}
             size="large"

--- a/src/features/member/list/MemberDetailHeader.tsx
+++ b/src/features/member/list/MemberDetailHeader.tsx
@@ -42,7 +42,7 @@ const MemberDetailHeader: FC<Props> = (props) => {
         </Typography>
         {!isEdit && (
           <OutlinedButton
-            leftIcon={<Pencil height="16" width="16" />}
+            leftIcon={<Pencil size="16" />}
             size="xsmall"
             variant="assistive"
             onClick={onClickToEdit}

--- a/src/pages/admin/attendances/AttendanceDetail.tsx
+++ b/src/pages/admin/attendances/AttendanceDetail.tsx
@@ -1,12 +1,11 @@
-import AttandanceTable from 'features/attendance/AttendanceTable';
-import SummaryTable from 'features/attendance/SummaryTable';
-import { FC } from 'react';
-
 import {
   AttendanceSession,
   AttendanceStatusValueType,
   AttendanceUser,
 } from 'apis/attendance/types';
+import AttandanceTable from 'features/attendance/AttendanceTable';
+import SummaryTable from 'features/attendance/SummaryTable';
+import { FC } from 'react';
 
 interface Props {
   sessions: AttendanceSession[] | undefined;

--- a/src/pages/admin/attendances/AttendanceEdit.tsx
+++ b/src/pages/admin/attendances/AttendanceEdit.tsx
@@ -1,12 +1,11 @@
-import AttendanceEditTable from 'features/attendance/AttendanceEditTable';
-import SummaryTable from 'features/attendance/SummaryTable';
-import { FC } from 'react';
-
 import {
   AttendanceSession,
   AttendanceStatusValueType,
   AttendanceUser,
 } from 'apis/attendance/types';
+import AttendanceEditTable from 'features/attendance/AttendanceEditTable';
+import SummaryTable from 'features/attendance/SummaryTable';
+import { FC } from 'react';
 
 interface Props {
   sessions: AttendanceSession[] | undefined;

--- a/src/pages/admin/members/MemberApplication.tsx
+++ b/src/pages/admin/members/MemberApplication.tsx
@@ -158,24 +158,22 @@ const MemberApplication: FC = () => {
                 </TableRow>
               </TableHead>
               <TableBody>
-                {data?.data.map((el, index) => {
+                {data?.data.map((el) => {
                   const id = el.id;
                   const isChecked = selectedIndexes.includes(id);
                   return (
-                    <TableRow key={el.id}>
-                      <TableCell>
+                    <TableRow key={el.id} onClick={() => onClickToDetail(el)}>
+                      <TableCell onClick={(e) => e.stopPropagation()}>
                         <Checkbox
                           state={isChecked ? 'checked' : 'unchecked'}
                           onClick={() => onClickRowCheck(id)}
                         />
                       </TableCell>
                       <TableCell>
-                        <Typography color="label-normal" variant="body1Normal">
-                          {index + 1}
-                        </Typography>
-                      </TableCell>
-                      <TableCell>
-                        <Typography color="label-normal" variant="body1Normal">
+                        <Typography
+                          color="primary-normal"
+                          variant="body1Normal"
+                        >
                           {el.name}
                         </Typography>
                       </TableCell>
@@ -217,9 +215,7 @@ const MemberApplication: FC = () => {
                         </Typography>
                       </TableCell>
                       <TableCell>
-                        <TextButton onClick={() => onClickToDetail(el)}>
-                          상세보기
-                        </TextButton>
+                        <TextButton>상세보기</TextButton>
                       </TableCell>
                     </TableRow>
                   );

--- a/src/pages/admin/members/MemberList.tsx
+++ b/src/pages/admin/members/MemberList.tsx
@@ -77,16 +77,16 @@ const MemberList: FC = () => {
                 </TableRow>
               </TableHead>
               <TableBody>
-                {data?.data.map((el, index) => (
+                {data?.data.map((el) => (
                   <TableRow key={el.userId} onClick={() => onClickRow(el)}>
-                    <TableCell>
-                      <Typography color="label-normal" variant="body1Normal">
-                        {index + 1}
-                      </Typography>
-                    </TableCell>
                     <TableCell>
                       <Typography color="primary-normal" variant="body1Normal">
                         {el.name}
+                      </Typography>
+                    </TableCell>
+                    <TableCell>
+                      <Typography color="label-normal" variant="body1Normal">
+                        {el.email}
                       </Typography>
                     </TableCell>
                     <TableCell>

--- a/src/pages/admin/notices/NoticeList.tsx
+++ b/src/pages/admin/notices/NoticeList.tsx
@@ -141,7 +141,7 @@ const NoticeList: FC = () => {
                 </TableRow>
               </TableHead>
               <TableBody>
-                {data?.data.map((notice, index) => {
+                {data?.data.map((notice) => {
                   const id = notice.noticeId;
                   const isChecked = selectedIndexes.includes(id);
                   return (
@@ -155,13 +155,12 @@ const NoticeList: FC = () => {
                           onClick={() => onClickRowCheck(id)}
                         />
                       </TableCell>
-                      <TableCell>
-                        <Typography color="label-normal" variant="body1Normal">
-                          {index + 1}
-                        </Typography>
-                      </TableCell>
+
                       <TableCell justifyContent="flex-start">
-                        <Typography color="label-normal" variant="body1Normal">
+                        <Typography
+                          color="primary-normal"
+                          variant="body1Normal"
+                        >
                           {notice.title}
                         </Typography>
                       </TableCell>

--- a/src/queries/user/useUserListQuery.ts
+++ b/src/queries/user/useUserListQuery.ts
@@ -15,6 +15,7 @@ export const useUserListQuery = ({ page, size }: PaginatedReq) => {
       data: response.data.data.data.map((user) => ({
         userId: user.userId,
         name: user.name,
+        email: user.email,
         generation: user.lastActivityUnit.generation,
         position: user.lastActivityUnit.position,
         role: user.role,


### PR DESCRIPTION
# 이 풀리퀘스트는 다음과 같습니다

## 📝 배경

QA 작업 진행

## 🛠️ 작업내용

- 회원 상세페이지 > 활동직군 수정 시 운영진 보이지 않는 이슈
- 회원 상세페이지 > 이메일 표시 
-  가입코드 팝업 닫기 버튼 노출
- 상세보기가 있는 페이지 번호 컬럼 제거, 이름 강조처리, 행 클릭 시 상세보기 가능하도록 수정
    - 회원리스트 / 가입신청서 / 공지사항 / 세션

## 📸 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

PR 리뷰어에게 공유할 내용이 있다면 설명해주세요.
이 PR을 리뷰하는 것에 도움이 될 수 있어요.
