### PR TITLE
fix: 사이드 네비게이션 active 개선

### DIFF
--- a/src/components/commons/SideNavList.tsx
+++ b/src/components/commons/SideNavList.tsx
@@ -12,6 +12,10 @@ interface Props {
 const SideNavList: FC<Props> = (props) => {
   const { pathname } = props;
 
+  const isActive = (path: string) => {
+    return pathname === path || pathname.startsWith(path + '/');
+  };
+
   return (
     <Container>
       {sideNavList.map((el) => (
@@ -20,8 +24,8 @@ const SideNavList: FC<Props> = (props) => {
             style={{ textDecoration: 'none', color: 'inherit' }}
             to={el.path}
           >
-            <Route $active={pathname === el.path}>
-              <NormalBlank active={pathname === el.path} />
+            <Route $active={isActive(el.path)}>
+              <NormalBlank active={isActive(el.path)} />
               <span>{el.title}</span>
             </Route>
           </Link>
@@ -34,11 +38,11 @@ const SideNavList: FC<Props> = (props) => {
               >
                 <Route
                   key={index}
-                  $active={pathname === child.path}
+                  $active={isActive(child.path)}
                   className="child"
                 >
                   <NormalBlank
-                    active={pathname === child.path}
+                    active={isActive(child.path)}
                     height="16"
                     width="16"
                   />

--- a/src/constants/sideNavList.ts
+++ b/src/constants/sideNavList.ts
@@ -3,7 +3,7 @@ import { NavList } from 'types/NavTypes';
 export const sideNavList: NavList[] = [
   {
     title: '회원관리',
-    path: '/admin',
+    path: '/admin/members',
     childs: [
       {
         title: '전체 회원 리스트',


### PR DESCRIPTION
# 이 풀리퀘스트는 다음과 같습니다

## 📝 배경

사이드바에서 메뉴를 선택할 때 상세 페이지 접근 시 메뉴가 비활성화(un-active) 되는 경우가 있어 이를 수정합니다.

## 🛠️ 작업내용

- 경로와 exact matching 외에도, `{기존 path}/` 이후 path가 추가되는 상세 페이지 접근 시 경로에서도 활성화될 수 있도록 수정했습니다.
- `회원관리`의 경우 `/admin` 경로로 되어 있는데, 항상 활성화되는 것으로 노출되어서 `/admin/members`로 변경했습니다.

## 📸 스크린샷 (선택)

| 출석 관리 > 출석 코드 관리 | 설정 > 강제 업데이트 |
| - | - |
| <img width="1796" height="2250" alt="CleanShot 2025-10-25 at 16 20 40@2x" src="https://github.com/user-attachments/assets/5aeff42d-6df9-4ae7-b4bf-6f93c559ba4f" /> | <img width="1796" height="2250" alt="CleanShot 2025-10-25 at 16 21 04@2x" src="https://github.com/user-attachments/assets/064936db-d4d6-40d3-8ce4-d5d142c1035a" /> |

| 공지시항 | 공지사항 > 상세 |
| - | - |
| <img width="1796" height="2250" alt="CleanShot 2025-10-25 at 16 19 59@2x" src="https://github.com/user-attachments/assets/4f591a8e-a954-47fb-93da-d0630f16ad88" /> | <img width="1796" height="2250" alt="CleanShot 2025-10-25 at 16 20 17@2x" src="https://github.com/user-attachments/assets/a13ef50b-d199-46bd-ab2e-b75dc814a01f" /> |

## 💬 리뷰 요구사항(선택)
