### PR TITLE
feat: SessionEdit 페이지 UI 수정

### DIFF
--- a/src/pages/admin/sessions/SessionEdit.tsx
+++ b/src/pages/admin/sessions/SessionEdit.tsx
@@ -2,8 +2,14 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { useQueryClient } from '@tanstack/react-query';
 import { isAxiosError } from 'axios';
 import dayjs from 'dayjs';
-import { FC, useEffect, useState } from 'react';
-import { Controller, FormProvider, useForm, useWatch } from 'react-hook-form';
+import { FC, useEffect, useMemo, useState } from 'react';
+import {
+  Controller,
+  FieldError,
+  FormProvider,
+  useForm,
+  useWatch,
+} from 'react-hook-form';
 import styled from 'styled-components';
 
 import CircleClose from '@assets/CircleClose';
@@ -13,9 +19,10 @@ import Calendar from '@compnents/commons/Calendar';
 import FlexBox from '@compnents/commons/FlexBox';
 import GridBox from '@compnents/commons/GridBox';
 import RadioGroup from '@compnents/commons/RadioGroup';
-import Select, { OptionType } from '@compnents/commons/Select';
-import TextInput from '@compnents/commons/TextInput';
+import Select from '@compnents/commons/Select';
+import TextInput, { State } from '@compnents/commons/TextInput';
 import Typography from '@compnents/commons/Typography';
+import { OptionType } from '@constants/optionList';
 import {
   hourOptions,
   minuteOptions,
@@ -93,6 +100,23 @@ const SessionEdit: FC<Props> = ({ handleEdit, data }) => {
   const [selectedUsers, setSelectedUsers] = useState<SelectedUsersMap>(() =>
     convertSessionAttendee(data?.attendees),
   );
+
+  const values = method.watch(['name', 'place', 'address']);
+  const { errors } = method.formState;
+
+  const states = useMemo(() => {
+    const getState = (value: string, error?: FieldError): State => {
+      if (!value) return 'default';
+      if (error) return 'error';
+      return 'success';
+    };
+
+    return {
+      name: getState(values[0], errors.name),
+      place: getState(values[1], errors.place),
+      address: getState(values[2], errors.address),
+    };
+  }, [values, errors]);
 
   useEffect(() => {
     if (!data || !eligibleUser) return;
@@ -216,32 +240,24 @@ const SessionEdit: FC<Props> = ({ handleEdit, data }) => {
         <Typography variant="title3Bold">세션 수정</Typography>
         <FlexBox direction="column" gap={24}>
           <GridBox align="center" columns="79px 1fr" gap={16}>
-            <Typography fontWeight={600} variant="body1Normal">
+            <Typography fontWeight={600} variant="headline1Bold">
               세션 타입
             </Typography>
-            <Controller
-              control={method.control}
-              name="sessionType"
-              render={({ field }) => (
-                <Select
-                  optionList={sessionTypeList}
-                  size="large"
-                  width="191px"
-                  selectedValue={
-                    sessionTypeList.find((item) => item.value === field.value)
-                      ?.value ?? ''
-                  }
-                  onChange={field.onChange}
-                />
+            <FlexBox direction="column">
+              <RadioGroup name="sessionType" options={sessionTypeList} />
+              {method.formState.errors.sessionType && (
+                <Typography color="status-negative" variant="caption1Regular">
+                  {method.formState.errors.sessionType.message}
+                </Typography>
               )}
-            />
+            </FlexBox>
           </GridBox>
           <GridBox fullWidth align="center" columns="79px 1fr" gap={16}>
-            <Typography fontWeight={600} variant="body1Normal">
+            <Typography fontWeight={600} variant="headline1Bold">
               제목
             </Typography>
             <FlexBox direction="column">
-              <TextInput {...method.register('name')} />
+              <TextInput {...method.register('name')} state={states.name} />
               {method.formState.errors.name && (
                 <Typography color="status-negative" variant="caption1Regular">
                   {method.formState.errors.name.message}
@@ -250,7 +266,7 @@ const SessionEdit: FC<Props> = ({ handleEdit, data }) => {
             </FlexBox>
           </GridBox>
           <GridBox align="center" columns="79px 1fr" gap={16}>
-            <Typography fontWeight={600} variant="body1Normal">
+            <Typography fontWeight={600} variant="headline1Bold">
               시작일
             </Typography>
             <FlexBox gap={20}>
@@ -269,6 +285,8 @@ const SessionEdit: FC<Props> = ({ handleEdit, data }) => {
                       <Select
                         optionList={hourOptions}
                         selectedValue={hour}
+                        size="large"
+                        width="130px"
                         onChange={(selectedHour) => {
                           const newTime = `${selectedHour}:${minute}:00`;
                           field.onChange(newTime);
@@ -277,6 +295,8 @@ const SessionEdit: FC<Props> = ({ handleEdit, data }) => {
                       <Select
                         optionList={minuteOptions}
                         selectedValue={minute}
+                        size="large"
+                        width="130px"
                         onChange={(selectedMinute) => {
                           const newTime = `${hour}:${selectedMinute}:00`;
                           field.onChange(newTime);
@@ -289,7 +309,7 @@ const SessionEdit: FC<Props> = ({ handleEdit, data }) => {
             </FlexBox>
           </GridBox>
           <GridBox align="center" columns="79px 1fr" gap={16}>
-            <Typography fontWeight={600} variant="body1Normal">
+            <Typography fontWeight={600} variant="headline1Bold">
               종료일
             </Typography>
             <FlexBox direction="column">
@@ -309,6 +329,8 @@ const SessionEdit: FC<Props> = ({ handleEdit, data }) => {
                         <Select
                           optionList={hourOptions}
                           selectedValue={hour}
+                          size="large"
+                          width="130px"
                           onChange={(selectedHour) => {
                             const newTime = `${selectedHour}:${minute}:00`;
                             field.onChange(newTime);
@@ -317,6 +339,8 @@ const SessionEdit: FC<Props> = ({ handleEdit, data }) => {
                         <Select
                           optionList={minuteOptions}
                           selectedValue={minute}
+                          size="large"
+                          width="130px"
                           onChange={(selectedMinute) => {
                             const newTime = `${hour}:${selectedMinute}:00`;
                             field.onChange(newTime);
@@ -335,11 +359,11 @@ const SessionEdit: FC<Props> = ({ handleEdit, data }) => {
             </FlexBox>
           </GridBox>
           <GridBox fullWidth align="center" columns="79px 1fr" gap={16}>
-            <Typography fontWeight={600} variant="body1Normal">
+            <Typography fontWeight={600} variant="headline1Bold">
               장소
             </Typography>
             <FlexBox direction="column">
-              <TextInput {...method.register('place')} />
+              <TextInput {...method.register('place')} state={states.place} />
               {method.formState.errors.place && (
                 <Typography color="status-negative" variant="caption1Regular">
                   {method.formState.errors.place.message}
@@ -348,11 +372,14 @@ const SessionEdit: FC<Props> = ({ handleEdit, data }) => {
             </FlexBox>
           </GridBox>
           <GridBox fullWidth align="center" columns="79px 1fr" gap={16}>
-            <Typography fontWeight={600} variant="body1Normal">
+            <Typography fontWeight={600} variant="headline1Bold">
               상세 주소
             </Typography>
             <FlexBox direction="column">
-              <TextInput {...method.register('address')} />
+              <TextInput
+                {...method.register('address')}
+                state={states.address}
+              />
               {method.formState.errors.address && (
                 <Typography color="status-negative" variant="caption1Regular">
                   {method.formState.errors.address.message}
@@ -368,7 +395,7 @@ const SessionEdit: FC<Props> = ({ handleEdit, data }) => {
             }}
           />
           <GridBox align="center" columns="79px 1fr" gap={16}>
-            <Typography fontWeight={600} variant="body1Normal">
+            <Typography fontWeight={600} variant="headline1Bold">
               기수
             </Typography>
             <Controller
@@ -397,7 +424,7 @@ const SessionEdit: FC<Props> = ({ handleEdit, data }) => {
           </GridBox>
 
           <GridBox fullWidth align="center" columns="79px 1fr" gap={16}>
-            <Typography fontWeight={600} variant="body1Normal">
+            <Typography fontWeight={600} variant="headline1Bold">
               세션 대상
             </Typography>
             <FlexBox align="center" gap={12}>
@@ -432,8 +459,8 @@ const SessionEdit: FC<Props> = ({ handleEdit, data }) => {
             }}
           />
 
-          <GridBox fullWidth columns="79px 1fr" gap={16}>
-            <Typography fontWeight={600} variant="body1Normal">
+          <GridBox fullWidth align="center" columns="79px 1fr" gap={16}>
+            <Typography fontWeight={600} variant="headline1Bold">
               공지사항
             </Typography>
             <FlexBox direction="column" gap={12}>
@@ -449,7 +476,7 @@ const SessionEdit: FC<Props> = ({ handleEdit, data }) => {
               {!!formNotices.length &&
                 formNotices.map((el) => (
                   <FlexBox key={el.noticeId} gap={16}>
-                    <Typography color="primary-normal" variant="body1Normal">
+                    <Typography color="primary-normal" variant="headline1Bold">
                       {el.title}
                     </Typography>
                     <IconButton onClick={() => removeNotice(el.noticeId)}>


### PR DESCRIPTION
# 이 풀리퀘스트는 다음과 같습니다

## 📝 배경

세션 수정 페이지에 위도/경도 적용 이전에 디자인과 다른 UI를 디자인에 맞게 수정했습니다.

## 🛠️ 작업내용

- https://github.com/YAPP-admin/yappu-world-admin/pull/68 변경 사항을 동일하게 반영했습니다.

## 📸 스크린샷 (선택)

| as-is | to-be |
| - | - |
| <img width="1278" height="962" alt="CleanShot 2025-12-31 at 02 37 03@2x" src="https://github.com/user-attachments/assets/c6f7159a-0d7a-4289-88f0-58f4635142ee" /> | <img width="1278" height="962" alt="CleanShot 2025-12-31 at 02 38 03@2x" src="https://github.com/user-attachments/assets/4dcb28ec-d5ca-42cb-b475-d6ed2a51e085" /> |

## Stacks

<!-- ejoffe/spr start -->
commit-id:827a0f7e

---

**Stack**:
- #72
- #71
- #70
- #69 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- ejoffe/spr end -->
