### PR TITLE
feat: 다음 주소 검색 SDK 연동 및 Kakao 주소 검색 연결

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "date-fns": "^4.1.0",
     "dayjs": "^1.11.13",
     "react": "^19.0.0",
+    "react-daum-postcode": "^3.2.0",
     "react-datepicker": "^8.2.1",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.54.2",

--- a/src/hooks/useDaumPostcode.ts
+++ b/src/hooks/useDaumPostcode.ts
@@ -1,0 +1,61 @@
+import { useState } from 'react';
+
+import { useSearchAddressMutation } from '@queries/kakao/useSearchAddressMutation';
+
+export interface AddressData {
+  address: string;
+  latitude: number;
+  longitude: number;
+}
+
+interface UseDaumPostcodeProps {
+  onComplete: (data: AddressData) => void;
+}
+
+export interface DaumPostcodeData {
+  roadAddress: string;
+  jibunAddress: string;
+  zonecode: string;
+}
+
+export const useDaumPostcode = ({ onComplete }: UseDaumPostcodeProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const { mutateAsync: searchAddress } = useSearchAddressMutation();
+
+  const openPostcode = () => {
+    setIsOpen(true);
+  };
+
+  const closePostcode = () => {
+    setIsOpen(false);
+  };
+
+  const handleComplete = async (data: DaumPostcodeData) => {
+    // 도로명 주소 혹은 지번 주소
+    const address = data.roadAddress || data.jibunAddress;
+
+    try {
+      const result = await searchAddress(address);
+
+      if (result && result.length > 0) {
+        const latitude = parseFloat(result[0].y);
+        const longitude = parseFloat(result[0].x);
+        onComplete({ address, latitude, longitude });
+      } else {
+        onComplete({ address, latitude: 0, longitude: 0 });
+      }
+    } catch (error) {
+      console.error('주소 좌표 변환 실패:', error);
+      onComplete({ address, latitude: 0, longitude: 0 });
+    } finally {
+      closePostcode();
+    }
+  };
+
+  return {
+    isOpen,
+    openPostcode,
+    closePostcode,
+    handleComplete,
+  };
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2955,6 +2955,11 @@ react-datepicker@^8.2.1:
     clsx "^2.1.1"
     date-fns "^4.1.0"
 
+react-daum-postcode@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/react-daum-postcode/-/react-daum-postcode-3.2.0.tgz#07fbbc38f4b0c48ee3c8f703eba5e4c9d82ffb2f"
+  integrity sha512-NHY8TUicZXMqykbKYT8kUo2PEU7xu1DFsdRmyWJrLEUY93Xhd3rEdoJ7vFqrvs+Grl9wIm9Byxh3bI+eZxepMQ==
+
 react-dom@^19.0.0:
   version "19.0.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-19.0.0.tgz#43446f1f01c65a4cd7f7588083e686a6726cfb57"


### PR DESCRIPTION
# 이 풀리퀘스트는 다음과 같습니다

## 📝 배경

세션 수정 페이지에 위도/경도 적용을 위해 react-daum-postcode 패키지를 추가하고 다음 주소 검색 기능과 Kakao Map SDK 주소 검색 기능을 연결했습니다.

## 🛠️ 작업내용

- https://github.com/YAPP-admin/yappu-world-admin/pull/70 에서 구현한 mutation을 사용합니다.
- 다음 주소 검색에서는 주소(도로명 주소 및 지번 주소) 문자열만 반환하는데, 이 문자열로부터 위도, 경도 정보를 조회하기 위해 Kakao Map SDK 주소 검색 인터페이스를 통해 추가로 조회해옵니다.

## Stacks

<!-- ejoffe/spr start -->
commit-id:ba6069bd

---

**Stack**:
- #72
- #71 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- ejoffe/spr end -->
